### PR TITLE
Quick hacky fix for ctctools.py

### DIFF
--- a/operators/ctctools.py
+++ b/operators/ctctools.py
@@ -96,7 +96,8 @@ def lastEdit(folder):
 
 currentPresetTime = 0
 script_file = os.path.realpath(__file__)
-directory =  os.path.dirname(os.path.dirname(script_file))
+# directory = os.path.dirname(os.path.dirname(script_file))
+directory = os.path.dirname(script_file)
 presetFolder = directory+"\\"+"CTCPresets"
 def initializePresets():
     global currentPresetTime


### PR DESCRIPTION
Removed doubly functions exec on filepaths, which broke plugin loading on windows. Now loads as it should.