### PR TITLE
linux compatibility

### DIFF
--- a/operators/ctctools.py
+++ b/operators/ctctools.py
@@ -99,7 +99,8 @@ currentPresetTime = 0
 script_file = os.path.realpath(__file__)
 directory = os.path.dirname(os.path.dirname(script_file))
 #directory = os.path.dirname(script_file)
-presetFolder = directory+"\\"+"CTCPresets"
+#presetFolder = directory+"\\"+"CTCPresets"
+presetFolder = os.path.join(directory, "CTCPresets")
 def initializePresets():
     global currentPresetTime
     presets = []


### PR DESCRIPTION
Fixes an issue on Linux where the presets could not be loaded because of a bad path.
Using `os.path.join` should fix it and still work on Windows.